### PR TITLE
Fix Lambda S3 bucket cross-region access error

### DIFF
--- a/agent-scaler.tf
+++ b/agent-scaler.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "scaler" {
   function_name = "${local.stack_name_full}-scaler"
   description   = "Scales ${aws_autoscaling_group.agent_auto_scale_group.name} based on Buildkite metrics"
 
-  s3_bucket = local.buildkite_lambda_bucket_mapping[data.aws_region.current.id]
+  s3_bucket = local.agent_scaler_s3_bucket
   s3_key    = "buildkite-agent-scaler/v${var.buildkite_agent_scaler_version}/handler.zip"
 
   handler       = "bootstrap"

--- a/locals.tf
+++ b/locals.tf
@@ -63,29 +63,9 @@ locals {
     cloudformation_stack_version = "v6.46.0"
   }
 
-  # Lambda functions are deployed from region-specific S3 buckets to avoid cross-region access errors
-  buildkite_lambda_bucket_mapping = {
-    us-east-1      = "buildkite-lambdas"
-    us-east-2      = "buildkite-lambdas-us-east-2"
-    us-west-1      = "buildkite-lambdas-us-west-1"
-    us-west-2      = "buildkite-lambdas-us-west-2"
-    af-south-1     = "buildkite-lambdas-af-south-1"
-    ap-east-1      = "buildkite-lambdas-ap-east-1"
-    ap-south-1     = "buildkite-lambdas-ap-south-1"
-    ap-northeast-2 = "buildkite-lambdas-ap-northeast-2"
-    ap-northeast-1 = "buildkite-lambdas-ap-northeast-1"
-    ap-southeast-2 = "buildkite-lambdas-ap-southeast-2"
-    ap-southeast-1 = "buildkite-lambdas-ap-southeast-1"
-    ca-central-1   = "buildkite-lambdas-ca-central-1"
-    eu-central-1   = "buildkite-lambdas-eu-central-1"
-    eu-west-1      = "buildkite-lambdas-eu-west-1"
-    eu-west-2      = "buildkite-lambdas-eu-west-2"
-    eu-south-1     = "buildkite-lambdas-eu-south-1"
-    eu-west-3      = "buildkite-lambdas-eu-west-3"
-    eu-north-1     = "buildkite-lambdas-eu-north-1"
-    me-south-1     = "buildkite-lambdas-me-south-1"
-    sa-east-1      = "buildkite-lambdas-sa-east-1"
-  }
+  # Region-specific Lambda deployment bucket
+  # us-east-1 uses "buildkite-lambdas", all other regions append the region suffix
+  agent_scaler_s3_bucket = data.aws_region.current.id == "us-east-1" ? "buildkite-lambdas" : "buildkite-lambdas-${data.aws_region.current.id}"
 
   # Detect ARM and burstable instances from instance type family
   instance_type_family = split(".", split(",", var.instance_types)[0])[0]


### PR DESCRIPTION
The agent-scaler Lambda was using a hardcoded "buildkite-lambdas" bucket, causing PermanentRedirect errors in regions outside us-east-1. Now uses region-specific buckets (e.g., buildkite-lambdas-us-west-2), incorporating the mapping from [the agent-scaler's SAM template](https://github.com/buildkite/buildkite-agent-scaler/blob/ac0883ab632a8689384ec8991c6415f8f3b48052/template.yaml#L166-L187).