### PR TITLE
Set agent-scaler LAMBDA_TIMEOUT to 50s

### DIFF
--- a/agent-scaler.tf
+++ b/agent-scaler.tf
@@ -37,7 +37,7 @@ resource "aws_lambda_function" "scaler" {
 
       # Lambda behavior /  Polling configuration
       LAMBDA_INTERVAL = var.scaler_min_poll_interval
-      LAMBDA_TIMEOUT  = "110s" # Less than function timeout to allow graceful exit
+      LAMBDA_TIMEOUT  = "50s" # Less than function timeout to allow graceful exit
 
       # Elastic CI Mode (experimental)
       ELASTIC_CI_MODE = var.scaler_enable_elastic_ci_mode ? "true" : "false"


### PR DESCRIPTION
This matches the default behavior in [buildkite-agent-scaler](https://github.com/buildkite/buildkite-agent-scaler/blob/e0fc691396725ad93af0834a5c821a525345dacb/template.yaml#L325) and prevents overlapping executions in the default configuration.

Fixes: #76
