### PR TITLE
Ignore subnet AZ changes after creation

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -26,6 +26,10 @@ resource "aws_subnet" "subnet0" {
   tags = merge(local.common_tags, {
     Name = "${local.stack_name_full}-subnet0"
   })
+
+  lifecycle {
+    ignore_changes = [availability_zone]
+  }
 }
 
 resource "aws_subnet" "subnet1" {
@@ -36,6 +40,10 @@ resource "aws_subnet" "subnet1" {
   tags = merge(local.common_tags, {
     Name = "${local.stack_name_full}-subnet1"
   })
+
+  lifecycle {
+    ignore_changes = [availability_zone]
+  }
 }
 
 resource "aws_route_table" "routes" {


### PR DESCRIPTION
AWS recently added new a new AZ - `us-east-1-bos-1a`. This new AZ became the (new) first item returned by the `aws_availability_zones` [data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones). This caused Terraform to want to re-create both of my existing subnets, which caused a failure loop because the VPC Endpoints created ENIs in the subnets and AWS won't delete subnets with ENIs attached.

The `availability_zone` on an `aws_subnet` is effectively immutable since AWS doesn't support cleanly moving a subnet to a different AZ. Adding a `lifecycle` to ignore changes to `availability_zone` will prevent this issue from occurring.