### PR TITLE
Deploy to every AZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ See [Licence.md](Licence.md) (MIT)
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
@@ -193,7 +193,7 @@ See [Licence.md](Licence.md) (MIT)
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
@@ -206,7 +206,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_autoscaling_group.agent_auto_scale_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_autoscaling_lifecycle_hook.instance_terminating](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_lifecycle_hook) | resource |
 | [aws_autoscaling_schedule.scheduled_scale_down_action](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_schedule) | resource |
@@ -243,8 +243,7 @@ No modules.
 | [aws_launch_template.agent_launch_template](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_route.route_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route_table.routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
-| [aws_route_table_association.subnet0_routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
-| [aws_route_table_association.subnet1_routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.subnet_routes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_s3_bucket.managed_secrets_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.managed_secrets_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_logging.managed_secrets_bucket_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
@@ -259,8 +258,7 @@ No modules.
 | [aws_security_group.security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_endpoint_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ssm_parameter.buildkite_agent_token_parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_subnet.subnet0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
-| [aws_subnet.subnet1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_endpoint.ec2messages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
@@ -282,7 +280,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_agent_endpoint"></a> [agent\_endpoint](#input\_agent\_endpoint) | API endpoint URL for Buildkite agent communication. Most customers shouldn't need to change this unless using a custom endpoint agreed with the Buildkite team. | `string` | `"https://agent.buildkite.com/v3"` | no |
 | <a name="input_agent_env_file_url"></a> [agent\_env\_file\_url](#input\_agent\_env\_file\_url) | Optional - HTTPS or S3 URL containing environment variables for the Buildkite agent process itself (not for builds). These variables configure agent behavior like proxy settings or debugging options. For build environment variables, use pipeline 'env' configuration instead. | `string` | `""` | no |
 | <a name="input_agents_per_instance"></a> [agents\_per\_instance](#input\_agents\_per\_instance) | Number of Buildkite agents to start on each EC2 instance. NOTE: If an agent crashes or is terminated, it won't be automatically restarted, leaving fewer active agents on that instance. The scale\_in\_idle\_period parameter controls when the entire instance terminates (when all agents are idle), not individual agent restarts. Consider enabling scaler\_enable\_elastic\_ci\_mode for better agent management, or use fewer agents per instance with more instances for high availability. | `number` | `1` | no |
@@ -410,7 +408,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_auto_scaling_group_arn"></a> [auto\_scaling\_group\_arn](#output\_auto\_scaling\_group\_arn) | ARN of the agent Auto Scaling Group |
 | <a name="output_auto_scaling_group_name"></a> [auto\_scaling\_group\_name](#output\_auto\_scaling\_group\_name) | Name of the agent Auto Scaling Group |
 | <a name="output_image_id"></a> [image\_id](#output\_image\_id) | AMI ID used by agent instances |

--- a/README.md
+++ b/README.md
@@ -260,9 +260,12 @@ No modules.
 | [aws_ssm_parameter.buildkite_agent_token_parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_subnet.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
-| [aws_vpc_endpoint.ec2messages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
-| [aws_vpc_endpoint.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
-| [aws_vpc_endpoint.ssmmessages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.ec2messages_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.ssm_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint.ssmmessages_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint_subnet_association.ec2messages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
+| [aws_vpc_endpoint_subnet_association.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
+| [aws_vpc_endpoint_subnet_association.ssmmessages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_subnet_association) | resource |
 | [aws_vpc_security_group_ingress_rule.security_group_ssh_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [random_id.stack_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [terraform_data.validate_agent_grace_periods](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -191,8 +191,7 @@ resource "aws_launch_template" "agent_launch_template" {
 resource "aws_autoscaling_group" "agent_auto_scale_group" {
   name = "${local.stack_name_full}-asg"
   vpc_zone_identifier = local.create_vpc ? [
-    aws_subnet.subnet0[0].id,
-    aws_subnet.subnet1[0].id
+    for subnet in aws_subnet.subnets : subnet.id
   ] : var.subnets
 
   mixed_instances_policy {

--- a/locals.tf
+++ b/locals.tf
@@ -13,6 +13,7 @@ locals {
   create_vpc            = var.vpc_id == ""
   create_security_group = length(var.security_group_ids) == 0
   use_custom_azs        = var.availability_zones != ""
+  availability_zones    = local.use_custom_azs ? split(",", var.availability_zones) : data.aws_availability_zones.available.names
 
   # Secrets and artifacts bucket settings
   create_secrets_bucket = var.enable_secrets_plugin && var.secrets_bucket == ""

--- a/vpc.tf
+++ b/vpc.tf
@@ -16,34 +16,14 @@ resource "aws_internet_gateway" "gateway" {
   })
 }
 
-
-
-resource "aws_subnet" "subnet0" {
-  count             = local.create_vpc ? 1 : 0
-  availability_zone = local.use_custom_azs ? element(split(",", var.availability_zones), 0) : element(data.aws_availability_zones.available.names, 0)
-  cidr_block        = "10.0.1.0/24"
+resource "aws_subnet" "subnets" {
+  for_each          = local.create_vpc ? { for idx, az in local.availability_zones : az => idx } : {}
+  availability_zone = each.key
+  cidr_block        = "10.0.${each.value}.0/24"
   vpc_id            = aws_vpc.vpc[0].id
   tags = merge(local.common_tags, {
-    Name = "${local.stack_name_full}-subnet0"
+    Name = "${local.stack_name_full}-subnet-${each.key}"
   })
-
-  lifecycle {
-    ignore_changes = [availability_zone]
-  }
-}
-
-resource "aws_subnet" "subnet1" {
-  count             = local.create_vpc ? 1 : 0
-  availability_zone = local.use_custom_azs ? element(split(",", var.availability_zones), 1) : element(data.aws_availability_zones.available.names, 1)
-  cidr_block        = "10.0.2.0/24"
-  vpc_id            = aws_vpc.vpc[0].id
-  tags = merge(local.common_tags, {
-    Name = "${local.stack_name_full}-subnet1"
-  })
-
-  lifecycle {
-    ignore_changes = [availability_zone]
-  }
 }
 
 resource "aws_route_table" "routes" {
@@ -59,15 +39,10 @@ resource "aws_route" "route_default" {
   route_table_id         = aws_route_table.routes[0].id
 }
 
-resource "aws_route_table_association" "subnet0_routes" {
-  count          = local.create_vpc ? 1 : 0
-  subnet_id      = aws_subnet.subnet0[0].id
-  route_table_id = aws_route_table.routes[0].id
-}
+resource "aws_route_table_association" "subnet_routes" {
+  for_each = aws_subnet.subnets
 
-resource "aws_route_table_association" "subnet1_routes" {
-  count          = local.create_vpc ? 1 : 0
-  subnet_id      = aws_subnet.subnet1[0].id
+  subnet_id      = aws_subnet.subnets[each.key].id
   route_table_id = aws_route_table.routes[0].id
 }
 
@@ -108,7 +83,7 @@ resource "aws_vpc_endpoint" "ssm" {
   vpc_id              = aws_vpc.vpc[0].id
   service_name        = "com.amazonaws.${data.aws_region.current.id}.ssm"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.subnet0[0].id, aws_subnet.subnet1[0].id]
+  subnet_ids          = [for subnet in aws_subnet.subnets : subnet.id]
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
   private_dns_enabled = true
 
@@ -122,7 +97,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   vpc_id              = aws_vpc.vpc[0].id
   service_name        = "com.amazonaws.${data.aws_region.current.id}.ssmmessages"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.subnet0[0].id, aws_subnet.subnet1[0].id]
+  subnet_ids          = [for subnet in aws_subnet.subnets : subnet.id]
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
   private_dns_enabled = true
 
@@ -136,7 +111,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
   vpc_id              = aws_vpc.vpc[0].id
   service_name        = "com.amazonaws.${data.aws_region.current.id}.ec2messages"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.subnet0[0].id, aws_subnet.subnet1[0].id]
+  subnet_ids          = [for subnet in aws_subnet.subnets : subnet.id]
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
   private_dns_enabled = true
 

--- a/vpc.tf
+++ b/vpc.tf
@@ -78,12 +78,11 @@ resource "aws_vpc_security_group_ingress_rule" "security_group_ssh_ingress" {
 }
 
 # VPC Endpoints for SSM connectivity
-resource "aws_vpc_endpoint" "ssm" {
+resource "aws_vpc_endpoint" "ssm_endpoint" {
   count               = local.create_vpc ? 1 : 0
   vpc_id              = aws_vpc.vpc[0].id
   service_name        = "com.amazonaws.${data.aws_region.current.id}.ssm"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = [for subnet in aws_subnet.subnets : subnet.id]
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
   private_dns_enabled = true
 
@@ -92,12 +91,17 @@ resource "aws_vpc_endpoint" "ssm" {
   })
 }
 
-resource "aws_vpc_endpoint" "ssmmessages" {
+resource "aws_vpc_endpoint_subnet_association" "ssm" {
+  for_each = aws_subnet.subnets
+  vpc_endpoint_id = aws_vpc_endpoint.ssm_endpoint[0].id
+  subnet_id       = aws_subnet.subnets[each.key].id
+}
+
+resource "aws_vpc_endpoint" "ssmmessages_endpoint" {
   count               = local.create_vpc ? 1 : 0
   vpc_id              = aws_vpc.vpc[0].id
   service_name        = "com.amazonaws.${data.aws_region.current.id}.ssmmessages"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = [for subnet in aws_subnet.subnets : subnet.id]
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
   private_dns_enabled = true
 
@@ -106,18 +110,29 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   })
 }
 
-resource "aws_vpc_endpoint" "ec2messages" {
+resource "aws_vpc_endpoint_subnet_association" "ssmmessages" {
+  for_each = aws_subnet.subnets
+  vpc_endpoint_id = aws_vpc_endpoint.ssmmessages_endpoint[0].id
+  subnet_id       = aws_subnet.subnets[each.key].id
+}
+
+resource "aws_vpc_endpoint" "ec2messages_endpoint" {
   count               = local.create_vpc ? 1 : 0
   vpc_id              = aws_vpc.vpc[0].id
   service_name        = "com.amazonaws.${data.aws_region.current.id}.ec2messages"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = [for subnet in aws_subnet.subnets : subnet.id]
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
   private_dns_enabled = true
 
   tags = merge(local.common_tags, {
     Name = "${local.stack_name_full}-ec2messages-endpoint"
   })
+}
+
+resource "aws_vpc_endpoint_subnet_association" "ec2messages" {
+  for_each = aws_subnet.subnets
+  vpc_endpoint_id = aws_vpc_endpoint.ec2messages_endpoint[0].id
+  subnet_id       = aws_subnet.subnets[each.key].id
 }
 
 # Security group for VPC endpoints


### PR DESCRIPTION
Previously the stack only supported two availability zones.
Now, the user can specify two or more AZs and the stack will use all of them.

Additionally, the stack will automatically deploy to all AZs of a region.

Note the second commit breaks the loop between subnets and VPC endpoints:

Subnets can't be deleted if they have active ENIs.
The VPN endpoints create ENIs.

The code I replaced fix es a deadlock where Terraform would not update the subnet_ids of the endpoints until it knew the new subnet IDs.
Moving the endpoint association into its own resource breaks that deadlock by more correctly modeling the resource graph.


Unfortunately this is not guaranteed to apply cleanly in one shot, but two tries seems to do it.
This is caused by two issues:


1. Since the subnets are being deleted and recreated, it is possible to conflict with another subnet in the process:
> InvalidSubnet.Conflict: The CIDR '10.0.2.0/24' conflicts with another subnet
One way to mitigate this would be to simply start at 3, since the current CIDRs are well known.


2. A side effect of needing to delete the VPC endpoints to be able to delete the subnets.
It is possible the initial create endpoint call fails on a conflicted domain:

> private-dns-enabled cannot be set because there is already a conflicting DNS domain for ssmmessages.us-east-2.amazonaws.com in the VPC vpc-01985ade6d17c8c8f

I'm not sure if there is a good way around this one.

If you're not interested in this PR I understand, but it only took a few minutes to put together and I'd rather it go upstream!