### PR TITLE
Prefix lambda ZIP output filenames with stack name

### DIFF
--- a/lifecycle-management.tf
+++ b/lifecycle-management.tf
@@ -17,7 +17,7 @@ resource "aws_lambda_function" "az_rebalancing_suspender" {
 
 data "archive_file" "az_rebalancing_suspender" {
   type        = "zip"
-  output_path = "${path.module}/.terraform/lambda/az-rebalancing-suspender.zip"
+  output_path = "${path.module}/.terraform/lambda/${local.stack_name_full}-az-rebalancing-suspender.zip"
 
   source {
     content  = <<-PYTHON
@@ -100,7 +100,7 @@ data "archive_file" "stop_buildkite_agents" {
   count = local.enable_graceful_shutdown ? 1 : 0
 
   type        = "zip"
-  output_path = "${path.module}/.terraform/lambda/stop-buildkite-agents.zip"
+  output_path = "${path.module}/.terraform/lambda/${local.stack_name_full}-stop-buildkite-agents.zip"
 
   source {
     content  = <<-PYTHON


### PR DESCRIPTION
Both `archive_file` resources wrote to hardcoded paths under `path.module`.

When the module is initiated multiple times via `for_each`, this results in the same directory being called for each instances.

This fix wraps the stack name within the path to remove collision.

Fixes #92