### PR TITLE
Use stable keys for managed policy attachments

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -42,7 +42,10 @@ resource "aws_iam_role_policy_attachment" "instance_ecr_policy" {
 
 # Attach custom managed policies if configured
 resource "aws_iam_role_policy_attachment" "instance_managed_policies" {
-  for_each   = local.use_custom_iam_role ? toset([]) : (local.use_managed_policies ? toset(var.managed_policy_arns) : toset([]))
+  for_each = local.use_custom_iam_role ? {} : {
+    for i, arn in var.managed_policy_arns : tostring(i) => arn
+  }
+
   role       = aws_iam_role.iam_role[0].name
   policy_arn = each.value
 }

--- a/locals.tf
+++ b/locals.tf
@@ -36,9 +36,6 @@ locals {
   role_tag_list  = compact(split(",", var.instance_role_tags))
   role_tag_count = length(local.role_tag_list)
 
-  use_managed_policies = length(var.managed_policy_arns) > 0
-
-
   # Image ID selection and parameter store settings
   use_custom_ami    = var.image_id != ""
   use_ami_parameter = var.image_id_parameter != ""


### PR DESCRIPTION
Changes managed policy attachments to use list indexes as `for_each` keys, so policy ARNs can be unknown until apply.