### PR TITLE
fix: scaler lambda policy uses the agent-token KMS key id as a raw ARN

### DIFF
--- a/agent-scaler.tf
+++ b/agent-scaler.tf
@@ -162,7 +162,7 @@ resource "aws_iam_role_policy" "scaler_lambda_policy" {
           Action = [
             "kms:Decrypt"
           ]
-          Resource = var.buildkite_agent_token_parameter_store_kms_key
+          Resource = "arn:aws:kms:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:key/${var.buildkite_agent_token_parameter_store_kms_key}"
         }
       ] : [],
       # Elastic CI Mode - Enhanced permissions for graceful scale-in


### PR DESCRIPTION
## Problem

`buildkite_agent_token_parameter_store_kms_key` is documented as a **key id** ("AWS KMS key ID used to encrypt the SSM parameter"), and `iam.tf` consumes it that way — constructing the full ARN for the instance role's `kms:Decrypt` statement. But the scaler-lambda policy in `agent-scaler.tf` uses the value **directly as the `Resource`**:

```hcl
# agent-scaler.tf
Action   = ["kms:Decrypt"]
Resource = var.buildkite_agent_token_parameter_store_kms_key
```

So when the variable is set to a bare key id (as documented), `terraform apply` fails:

```
operation error IAM: PutRolePolicy, MalformedPolicyDocument:
Resource <key-id> must be in ARN format or "*".
```

There's no value that works for both policies: a bare id breaks the scaler policy here, while a full ARN double-prefixes in `iam.tf` (`…:key/arn:aws:kms:…:key/<id>`). The only way to apply with a customer-managed key today is `"*"`, which over-broadens `kms:Decrypt` to every key in the account.

## Fix

Build the ARN from the key id, matching what `iam.tf` already does:

```hcl
Resource = "arn:aws:kms:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:key/${var.buildkite_agent_token_parameter_store_kms_key}"
```

A bare key id now scopes `kms:Decrypt` to that single key on both the instance role and the scaler lambda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)