### PR TITLE
Update tf-docs tag, script

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,7 @@ steps:
           - "README.md"
         plugins:
           - docker#v5.13.0:
-              image: "quay.io/terraform-docs/terraform-docs:latest"
+              image: "quay.io/terraform-docs/terraform-docs:latest-amd64"
               workdir: "/workdir"
               entrypoint: "/bin/sh"
 

--- a/.buildkite/scripts/docs-check.sh
+++ b/.buildkite/scripts/docs-check.sh
@@ -7,6 +7,7 @@ if ! command -v git &> /dev/null; then
 fi
 
 echo "Generating documentation..."
+terraform-docs --version
 echo "Current commit: $(git rev-parse HEAD 2>/dev/null || echo 'not a git repo')"
 echo "README.md before generation:"
 md5sum README.md || true


### PR DESCRIPTION
Images for `terraform-docs` are now being [published](https://quay.io/repository/terraform-docs/terraform-docs?tab=tags) with `-<arch>` appended to the tags. The last version tagged with `latest` was `0.20.0`.