### PR TITLE
fix: run AMI update script on direct pushes

### DIFF
--- a/.buildkite/scripts/check_version_change.sh
+++ b/.buildkite/scripts/check_version_change.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/bash
 set -euo pipefail
 
-if [ ${BUILDKITE_PULL_REQUEST} == "false" ]; then
-  echo "Not a pull request, skipping version change check." >&2
-  exit 0
-fi
-
+# Detect if the cloudformation_stack_version has changed since main.
+# This runs on both PRs and direct pushes (e.g. Renovate commits), so AMI
+# mappings are always kept in sync with the stack version.
 git fetch --depth=1 origin main >&2
 
 if git diff origin/main...HEAD -- locals.tf | grep -q 'cloudformation_stack_version'; then


### PR DESCRIPTION
Renovate pushes directly to its branch before opening a PR; removing the PR only guard ensures AMI mappings are updated inline with each version bump instead of being left stale until a PR is created.