### PR TITLE
fix: replace deprecated `aws_region.current.id` with `.region`

### DIFF
--- a/agent-scaler.tf
+++ b/agent-scaler.tf
@@ -152,7 +152,7 @@ resource "aws_iam_role_policy" "scaler_lambda_policy" {
           Action = [
             "ssm:GetParameter"
           ]
-          Resource = local.use_custom_token_path ? "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter${var.buildkite_agent_token_parameter_store_path}" : aws_ssm_parameter.buildkite_agent_token_parameter[0].arn
+          Resource = local.use_custom_token_path ? "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter${var.buildkite_agent_token_parameter_store_path}" : aws_ssm_parameter.buildkite_agent_token_parameter[0].arn
         }
       ],
       # KMS for encrypted SSM parameter (if using customer-managed key)
@@ -162,7 +162,7 @@ resource "aws_iam_role_policy" "scaler_lambda_policy" {
           Action = [
             "kms:Decrypt"
           ]
-          Resource = "arn:aws:kms:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:key/${var.buildkite_agent_token_parameter_store_kms_key}"
+          Resource = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/${var.buildkite_agent_token_parameter_store_kms_key}"
         }
       ] : [],
       # Elastic CI Mode - Enhanced permissions for graceful scale-in
@@ -186,8 +186,8 @@ resource "aws_iam_role_policy" "scaler_lambda_policy" {
             "ssm:GetCommandInvocation"
           ]
           Resource = [
-            "arn:aws:ssm:${data.aws_region.current.id}::document/AWS-RunShellScript",
-            "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:instance/*"
+            "arn:aws:ssm:${data.aws_region.current.region}::document/AWS-RunShellScript",
+            "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:instance/*"
           ]
         }
       ] : [],
@@ -197,7 +197,7 @@ resource "aws_iam_role_policy" "scaler_lambda_policy" {
           Action = [
             "ec2:TerminateInstances"
           ]
-          Resource = "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:instance/*"
+          Resource = "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:instance/*"
           Condition = {
             StringEquals = {
               "ec2:ResourceTag/aws:autoscaling:groupName" = aws_autoscaling_group.agent_auto_scale_group.name

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -91,9 +91,9 @@ resource "aws_launch_template" "agent_launch_template" {
     stack_deployed_by                             = "terraform"
     scale_in_idle_period                          = var.scale_in_idle_period
     secrets_bucket                                = local.create_secrets_bucket ? aws_s3_bucket.managed_secrets_bucket[0].id : var.secrets_bucket
-    secrets_bucket_region                         = local.create_secrets_bucket ? data.aws_region.current.id : var.secrets_bucket_region
+    secrets_bucket_region                         = local.create_secrets_bucket ? data.aws_region.current.region : var.secrets_bucket_region
     artifacts_bucket                              = var.artifacts_bucket
-    artifacts_bucket_region                       = local.use_artifacts_bucket ? coalesce(var.artifacts_bucket_region, data.aws_region.current.id) : data.aws_region.current.id
+    artifacts_bucket_region                       = local.use_artifacts_bucket ? coalesce(var.artifacts_bucket_region, data.aws_region.current.region) : data.aws_region.current.region
     artifacts_s3_acl                              = var.artifacts_s3_acl
     agent_token_path                              = local.use_custom_token_path ? var.buildkite_agent_token_parameter_store_path : aws_ssm_parameter.buildkite_agent_token_parameter[0].name
     agents_per_instance                           = var.agents_per_instance
@@ -120,7 +120,7 @@ resource "aws_launch_template" "agent_launch_template" {
     purge_builds_on_disk_full                     = var.buildkite_purge_builds_on_disk_full ? "true" : "false"
     additional_sudo_permissions                   = var.buildkite_additional_sudo_permissions
     buildkite_windows_administrator               = var.buildkite_windows_administrator ? "true" : "false"
-    aws_region                                    = data.aws_region.current.id
+    aws_region                                    = data.aws_region.current.region
     enable_secrets_plugin                         = var.enable_secrets_plugin ? "true" : "false"
     secrets_plugin_skip_ssh_key_not_found_warning = var.secrets_plugin_skip_ssh_key_not_found_warning ? "true" : "false"
     enable_ecr_plugin                             = var.enable_ecr_plugin ? "true" : "false"
@@ -134,9 +134,9 @@ resource "aws_launch_template" "agent_launch_template" {
     stack_deployed_by                             = "terraform"
     scale_in_idle_period                          = var.scale_in_idle_period
     secrets_bucket                                = local.create_secrets_bucket ? aws_s3_bucket.managed_secrets_bucket[0].id : var.secrets_bucket
-    secrets_bucket_region                         = local.create_secrets_bucket ? data.aws_region.current.id : var.secrets_bucket_region
+    secrets_bucket_region                         = local.create_secrets_bucket ? data.aws_region.current.region : var.secrets_bucket_region
     artifacts_bucket                              = var.artifacts_bucket
-    artifacts_bucket_region                       = local.use_artifacts_bucket ? coalesce(var.artifacts_bucket_region, data.aws_region.current.id) : data.aws_region.current.id
+    artifacts_bucket_region                       = local.use_artifacts_bucket ? coalesce(var.artifacts_bucket_region, data.aws_region.current.region) : data.aws_region.current.region
     artifacts_s3_acl                              = var.artifacts_s3_acl
     agent_token_path                              = local.use_custom_token_path ? var.buildkite_agent_token_parameter_store_path : aws_ssm_parameter.buildkite_agent_token_parameter[0].name
     agents_per_instance                           = var.agents_per_instance
@@ -165,7 +165,7 @@ resource "aws_launch_template" "agent_launch_template" {
     terminate_instance_on_disk_full               = var.buildkite_terminate_instance_on_disk_full ? "true" : "false"
     purge_builds_on_disk_full                     = var.buildkite_purge_builds_on_disk_full ? "true" : "false"
     additional_sudo_permissions                   = var.buildkite_additional_sudo_permissions
-    aws_region                                    = data.aws_region.current.id
+    aws_region                                    = data.aws_region.current.region
     enable_secrets_plugin                         = var.enable_secrets_plugin ? "true" : "false"
     secrets_plugin_skip_ssh_key_not_found_warning = var.secrets_plugin_skip_ssh_key_not_found_warning ? "true" : "false"
     enable_ecr_plugin                             = var.enable_ecr_plugin ? "true" : "false"

--- a/iam.tf
+++ b/iam.tf
@@ -191,7 +191,7 @@ resource "aws_iam_role_policy" "buildkite_agent_policy" {
           Sid      = "DecryptAgentToken"
           Effect   = "Allow"
           Action   = "kms:Decrypt"
-          Resource = "arn:aws:kms:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:key/${var.buildkite_agent_token_parameter_store_kms_key}"
+          Resource = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/${var.buildkite_agent_token_parameter_store_kms_key}"
         }
       ] : []
     )
@@ -336,7 +336,7 @@ resource "aws_iam_role_policy" "stop_buildkite_agents_ssm_document" {
     Statement = [{
       Effect   = "Allow"
       Action   = "ssm:SendCommand"
-      Resource = "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.id}::document/AWS-RunShellScript"
+      Resource = "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.region}::document/AWS-RunShellScript"
     }]
   })
 }
@@ -352,7 +352,7 @@ resource "aws_iam_role_policy" "stop_buildkite_agents_ssm_instances" {
     Statement = [{
       Effect   = "Allow"
       Action   = "ssm:SendCommand"
-      Resource = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:instance/*"
+      Resource = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:instance/*"
       Condition = {
         StringEquals = {
           "aws:ResourceTag/aws:autoscaling:groupName" = aws_autoscaling_group.agent_auto_scale_group.name

--- a/locals.tf
+++ b/locals.tf
@@ -71,7 +71,7 @@ locals {
 
   # Region-specific Lambda deployment bucket
   # us-east-1 uses "buildkite-lambdas", all other regions append the region suffix
-  agent_scaler_s3_bucket         = data.aws_region.current.id == "us-east-1" ? "buildkite-lambdas" : "buildkite-lambdas-${data.aws_region.current.id}"
+  agent_scaler_s3_bucket         = data.aws_region.current.region == "us-east-1" ? "buildkite-lambdas" : "buildkite-lambdas-${data.aws_region.current.region}"
   buildkite_agent_scaler_version = "1.12.0"
   # Detect ARM and burstable instances from instance type family
   instance_type_family = split(".", split(",", var.instance_types)[0])[0]
@@ -92,7 +92,7 @@ locals {
 
   is_windows       = var.instance_operating_system == "windows"
   ami_architecture = local.is_windows ? "windows" : (local.is_arm_instance ? "linuxarm64" : "linuxamd64")
-  selected_ami_id  = local.buildkite_ami_mapping[data.aws_region.current.id][local.ami_architecture]
+  selected_ami_id  = local.buildkite_ami_mapping[data.aws_region.current.region][local.ami_architecture]
 
   # Instance naming and timeout settings
   use_default_timeout      = var.instance_creation_timeout == ""
@@ -123,7 +123,7 @@ locals {
   signing_key_is_arn       = startswith(var.pipeline_signing_kms_key_id, "arn:")
 
   # Computed signing key ARN (for use in templates)
-  signing_key_arn = local.create_signing_key ? "arn:aws:kms:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:key/${aws_kms_key.pipeline_signing_kms_key[0].key_id}" : var.pipeline_signing_kms_key_id
+  signing_key_arn = local.create_signing_key ? "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/${aws_kms_key.pipeline_signing_kms_key[0].key_id}" : var.pipeline_signing_kms_key_id
 
   # Computed agent token parameter ARN (for IAM policies)
   agent_token_parameter_arn = local.use_custom_token_path ? "arn:aws:ssm:*:*:parameter${var.buildkite_agent_token_parameter_store_path}" : "arn:aws:ssm:*:*:parameter/buildkite/elastic-ci-stack/${local.stack_name_full}/agent-token"

--- a/vpc.tf
+++ b/vpc.tf
@@ -106,7 +106,7 @@ resource "aws_vpc_security_group_ingress_rule" "security_group_ssh_ingress" {
 resource "aws_vpc_endpoint" "ssm" {
   count               = local.create_vpc ? 1 : 0
   vpc_id              = aws_vpc.vpc[0].id
-  service_name        = "com.amazonaws.${data.aws_region.current.id}.ssm"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ssm"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = [aws_subnet.subnet0[0].id, aws_subnet.subnet1[0].id]
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
@@ -120,7 +120,7 @@ resource "aws_vpc_endpoint" "ssm" {
 resource "aws_vpc_endpoint" "ssmmessages" {
   count               = local.create_vpc ? 1 : 0
   vpc_id              = aws_vpc.vpc[0].id
-  service_name        = "com.amazonaws.${data.aws_region.current.id}.ssmmessages"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ssmmessages"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = [aws_subnet.subnet0[0].id, aws_subnet.subnet1[0].id]
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
@@ -134,7 +134,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
 resource "aws_vpc_endpoint" "ec2messages" {
   count               = local.create_vpc ? 1 : 0
   vpc_id              = aws_vpc.vpc[0].id
-  service_name        = "com.amazonaws.${data.aws_region.current.id}.ec2messages"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ec2messages"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = [aws_subnet.subnet0[0].id, aws_subnet.subnet1[0].id]
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]


### PR DESCRIPTION
AWS provider 6.x deprecates `.id` and `.name` on the `aws_region` data source in favor of `.region`. Silences 23 validation warnings that were raised via `terraform validate`. This results in no behavior changes.