### PR TITLE
Allow choosing between Amazon Linux and Ubuntu AMIs

### DIFF
--- a/.buildkite/scripts/update_amis.sh
+++ b/.buildkite/scripts/update_amis.sh
@@ -148,8 +148,8 @@ update_ami_mappings() {
   echo "  buildkite_ami_mapping = {" > "$temp_mapping"
 
   # Use yq to parse YAML reliably, then format with awk for padding
-  echo "$yaml_content" | yq -r '.Mappings.AWSRegion2AMI | to_entries[] | "\(.key)|\(.value.linuxamd64)|\(.value.linuxarm64)|\(.value.windows)"' | \
-    awk -F'|' '{printf "    %-28s = { linuxamd64 = \"%-21s\", linuxarm64 = \"%-21s\", windows = \"%-21s\" }\n", $1, $2, $3, $4}' >> "$temp_mapping"
+  echo "$yaml_content" | yq -r '.Mappings.AWSRegion2AMI | to_entries[] | "\(.key)|\(.value.linuxamd64)|\(.value.linuxarm64)|\(.value.windows)|\(.value.ubuntu2404amd64)|\(.value.ubuntu2404arm64)"' | \
+    awk -F'|' '{printf "    %-28s = { linuxamd64 = \"%-21s\", linuxarm64 = \"%-21s\", windows = \"%-21s\", ubuntu2404amd64 = \"%-21s\", ubuntu2404arm64 = \"%-21s\" }\n", $1, $2, $3, $4, $5, $6}' >> "$temp_mapping"
 
   echo "    cloudformation_stack_version = \"$version\"" >> "$temp_mapping"
   echo "  }" >> "$temp_mapping"

--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ Buildkite builds and deploys the following AMIs to all our supported regions:
 
 - Amazon Linux 2023 (64-bit x86)
 - Amazon Linux 2023 (64-bit Arm)
+- Ubuntu 24.04 LTS (64-bit x86)
+- Ubuntu 24.04 LTS (64-bit Arm)
 - Windows Server 2022 (64-bit x86)
+
+Amazon Linux 2023 is the default for Linux instances. To use Ubuntu 24.04 LTS instead, set `linux_distribution = "ubuntu2404"`.
 
 ## Recommended reading
 
@@ -291,7 +295,7 @@ No modules.
 | <a name="input_artifacts_s3_acl"></a> [artifacts\_s3\_acl](#input\_artifacts\_s3\_acl) | Optional - ACL to use for S3 artifact uploads. | `string` | `"private"` | no |
 | <a name="input_asg_process_suspender_role_arn"></a> [asg\_process\_suspender\_role\_arn](#input\_asg\_process\_suspender\_role\_arn) | Optional - ARN of an existing IAM role to attach to the ASG process suspender Lambda function instead of creating a new role.<br/>When specified, the module will not create any IAM roles or policies for the ASG process suspender Lambda, and will use this role instead.<br/>The role must have all necessary permissions for the ASG process suspender Lambda to function correctly.<br/>This is useful when you want to share a single IAM role across multiple queues/stacks.<br/>See https://buildkite.com/docs/agent/v3/aws/elastic-ci-stack/ec2-linux-and-windows/managing-elastic-ci-stack#using-custom-iam-roles<br/>for required permissions and configuration examples. | `string` | `""` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Give instances public IP addresses for direct internet access. Set to false for a more isolated environment if the VPC has alternative outbound internet access configured. | `bool` | `true` | no |
-| <a name="input_authorized_users_url"></a> [authorized\_users\_url](#input\_authorized\_users\_url) | Optional - HTTPS or S3 URL to periodically download SSH authorized\_keys from, setting this will enable SSH ingress. authorized\_keys are applied to ec2-user. | `string` | `""` | no |
+| <a name="input_authorized_users_url"></a> [authorized\_users\_url](#input\_authorized\_users\_url) | Optional - HTTPS or S3 URL to periodically download SSH authorized\_keys from, setting this will enable SSH ingress. authorized\_keys are applied to the default login user (ec2-user on Amazon Linux, ubuntu on Ubuntu). | `string` | `""` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Optional - Comma separated list of AZs that subnets are created in (if subnets parameter is not specified). | `string` | `""` | no |
 | <a name="input_bootstrap_script_url"></a> [bootstrap\_script\_url](#input\_bootstrap\_script\_url) | Optional - HTTPS or S3 URL for a script to run on each instance during boot. | `string` | `""` | no |
 | <a name="input_buildkite_additional_sudo_permissions"></a> [buildkite\_additional\_sudo\_permissions](#input\_buildkite\_additional\_sudo\_permissions) | Optional - Comma-separated list of specific commands (full paths) that build jobs can run with sudo privileges. Include only commands essential for builds. Leave blank unless builds require specific system-level operations. | `string` | `""` | no |
@@ -355,9 +359,10 @@ No modules.
 | <a name="input_instance_role_permissions_boundary_arn"></a> [instance\_role\_permissions\_boundary\_arn](#input\_instance\_role\_permissions\_boundary\_arn) | Optional - The ARN of the policy used to set the permissions boundary for the role when creating a new role. Ignored when instance\_role\_arn is provided. | `string` | `""` | no |
 | <a name="input_instance_role_tags"></a> [instance\_role\_tags](#input\_instance\_role\_tags) | Optional - Comma-separated key=value pairs for instance IAM role tags (up to 5 tags). Example: 'Environment=production,Team=platform,Purpose=ci'. Note: Keys and values cannot contain '=' characters. Only applied when creating a new role, ignored when instance\_role\_arn is provided. | `string` | `""` | no |
 | <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | EC2 instance types to use (comma-separated, up to 25). The first type listed is preferred for OnDemand instances. Additional types improve Spot instance availability but make costs less predictable. Examples: 't3.large' for light workloads, 'm5.xlarge,m5a.xlarge' for CPU-intensive builds, 'c5.2xlarge,c5.4xlarge' for compute-heavy tasks. | `string` | `"t3.large"` | no |
-| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Optional - SSH keypair used to access the Buildkite instances via ec2-user, setting this will enable SSH ingress. | `string` | `""` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Optional - SSH keypair used to access the Buildkite instances via the default login user (ec2-user on Amazon Linux, ubuntu on Ubuntu), setting this will enable SSH ingress. | `string` | `""` | no |
 | <a name="input_lambda_architecture"></a> [lambda\_architecture](#input\_lambda\_architecture) | CPU architecture for Lambda functions (x86\_64 or arm64). arm64 provides better price-performance but requires compatible dependencies. | `string` | `"x86_64"` | no |
 | <a name="input_lambda_log_retention_days"></a> [lambda\_log\_retention\_days](#input\_lambda\_log\_retention\_days) | The number of days to retain CloudWatch Logs for Lambda functions in the stack. | `number` | `1` | no |
+| <a name="input_linux_distribution"></a> [linux\_distribution](#input\_linux\_distribution) | The Linux distribution to run on the instances. Only applies when instance\_operating\_system is 'linux'. | `string` | `"amazonlinux2023"` | no |
 | <a name="input_managed_policy_arns"></a> [managed\_policy\_arns](#input\_managed\_policy\_arns) | Optional - List of managed IAM policy ARNs to attach to the instance role. | `list(string)` | `[]` | no |
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maximum number of instances. Controls cost ceiling and prevents runaway scaling. | `number` | `10` | no |
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Minimum number of instances. Ensures baseline capacity for immediate job execution. | `number` | `0` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -44,30 +44,30 @@ locals {
   use_custom_ami    = var.image_id != ""
   use_ami_parameter = var.image_id_parameter != ""
 
-  # Region-specific AMI IDs by architecture (linux-amd64, linux-arm64, windows)
+  # Region-specific AMI IDs by distribution and architecture
   # AMI mappings for Buildkite Agent - these are the latest built AMIs from elastic-ci-stack-for-aws
   # See https://github.com/buildkite/elastic-ci-stack-for-aws for source
   buildkite_ami_mapping = {
-    us-east-1                    = { linuxamd64 = "ami-002307738ad1dfff7", linuxarm64 = "ami-04c91cb4a57575fd8", windows = "ami-0045afbb662364758" }
-    us-east-2                    = { linuxamd64 = "ami-02a6bd3a0a58c9bb7", linuxarm64 = "ami-0796ad56a222cb489", windows = "ami-0eda89c43441add73" }
-    us-west-1                    = { linuxamd64 = "ami-0da1a438c181ad519", linuxarm64 = "ami-0a555887d56e42164", windows = "ami-0ac3de65d39708f3f" }
-    us-west-2                    = { linuxamd64 = "ami-0e9730172ff596a7a", linuxarm64 = "ami-0619e281f7592fefa", windows = "ami-0edb193c6ac1c111f" }
-    af-south-1                   = { linuxamd64 = "ami-0e146a2d1eabadd96", linuxarm64 = "ami-0a6c4805b2bde2211", windows = "ami-07b647ba6f3115edb" }
-    ap-east-1                    = { linuxamd64 = "ami-0fde42fdd68182e4a", linuxarm64 = "ami-0d506f37414d0581b", windows = "ami-079ec44e88e6a67b0" }
-    ap-south-1                   = { linuxamd64 = "ami-0699c2ac0668abdd4", linuxarm64 = "ami-09153364ddeb20751", windows = "ami-0fd1c544f41ffb2fe" }
-    ap-northeast-2               = { linuxamd64 = "ami-03a6c0d481cab103f", linuxarm64 = "ami-05c01299ffd53a7c4", windows = "ami-00cfb8931590deeb1" }
-    ap-northeast-1               = { linuxamd64 = "ami-051c6e46e25bdc1b5", linuxarm64 = "ami-01c09e7666d807b9f", windows = "ami-09a60f16955a0b102" }
-    ap-southeast-2               = { linuxamd64 = "ami-08b40220484ae7d97", linuxarm64 = "ami-0ff5a1ce53822b287", windows = "ami-0330bb4c334943f29" }
-    ap-southeast-1               = { linuxamd64 = "ami-00ab4b3adfa39058a", linuxarm64 = "ami-00712e16c306a72e6", windows = "ami-0a41ca34003d1461c" }
-    ca-central-1                 = { linuxamd64 = "ami-00dec5f5418769036", linuxarm64 = "ami-09e506dde01e9a8e8", windows = "ami-0e43fb9c03c7a7b60" }
-    eu-central-1                 = { linuxamd64 = "ami-06d44212456d1458f", linuxarm64 = "ami-084e3cd36c1e0d6ad", windows = "ami-0733e971baf35bd3e" }
-    eu-west-1                    = { linuxamd64 = "ami-03e7aeac8063a5b99", linuxarm64 = "ami-063c1c28940ea161b", windows = "ami-0b7841fe9188e35dc" }
-    eu-west-2                    = { linuxamd64 = "ami-0b3c594a6759f8f93", linuxarm64 = "ami-07fbfa7d74c3a538b", windows = "ami-07b10750764ade7da" }
-    eu-south-1                   = { linuxamd64 = "ami-08eafd14d10e97cf4", linuxarm64 = "ami-08510ced75b37abb3", windows = "ami-0ca64a19150dfe7d0" }
-    eu-west-3                    = { linuxamd64 = "ami-02bd2f34af2441578", linuxarm64 = "ami-0645abe96071ec6cb", windows = "ami-0b3a561ecb30612ac" }
-    eu-north-1                   = { linuxamd64 = "ami-01d59cf83a965003f", linuxarm64 = "ami-010e34ebd2b1483e2", windows = "ami-01b4514b7376c68f1" }
-    sa-east-1                    = { linuxamd64 = "ami-0cf84c780a6e119bd", linuxarm64 = "ami-05ff40993c3a54699", windows = "ami-077b089e07dec4cb5" }
-    cloudformation_stack_version = "v6.69.2"
+    us-east-1                    = { linuxamd64 = "ami-0bc1117b0015fd07b", linuxarm64 = "ami-057856d0c248f58e0", windows = "ami-00b2b7e9f61b98d6f", ubuntu2404amd64 = "ami-0cde1d56eff2ff7e1", ubuntu2404arm64 = "ami-0c47b2f75b5f8ce2e" }
+    us-east-2                    = { linuxamd64 = "ami-011953657ee1ab99b", linuxarm64 = "ami-0746ab61475de82c3", windows = "ami-03500817d96eaa3fd", ubuntu2404amd64 = "ami-0065308ff115b09a2", ubuntu2404arm64 = "ami-083a4cfd99c72d699" }
+    us-west-1                    = { linuxamd64 = "ami-0dd649d27163217b8", linuxarm64 = "ami-0284b3cd0a8c7107f", windows = "ami-07bd14ecc07b5acb2", ubuntu2404amd64 = "ami-09a8cd986aafc077f", ubuntu2404arm64 = "ami-0f578ef195e7e45a0" }
+    us-west-2                    = { linuxamd64 = "ami-0ff9de06c17000d8e", linuxarm64 = "ami-0aef68c342bfc7aca", windows = "ami-0d626da95055f6f7f", ubuntu2404amd64 = "ami-00ce1412c68e5bbff", ubuntu2404arm64 = "ami-0f76f528a81080044" }
+    af-south-1                   = { linuxamd64 = "ami-026799d1726a379a0", linuxarm64 = "ami-024081ab783df7ff7", windows = "ami-0aebf965c1baba766", ubuntu2404amd64 = "ami-0cb60deb6d8dea26b", ubuntu2404arm64 = "ami-0f32b70643f06e4c8" }
+    ap-east-1                    = { linuxamd64 = "ami-0e58ef5b5c4e03a6d", linuxarm64 = "ami-0a51e3a1ad144518d", windows = "ami-0c75667c7d9901cec", ubuntu2404amd64 = "ami-05c4f5ec66a57ff6c", ubuntu2404arm64 = "ami-01c457ad5dc468c29" }
+    ap-south-1                   = { linuxamd64 = "ami-0a015da676a4fac1e", linuxarm64 = "ami-035dcddabdf130e45", windows = "ami-0548d355d99dab5d5", ubuntu2404amd64 = "ami-0a6d1a61b6be99986", ubuntu2404arm64 = "ami-081c56056780d3cef" }
+    ap-northeast-2               = { linuxamd64 = "ami-0fc001ac730a9e092", linuxarm64 = "ami-012df1f5605eba1e1", windows = "ami-026c68e2fd52a48c4", ubuntu2404amd64 = "ami-0b564b6ebc440041b", ubuntu2404arm64 = "ami-07a668fe483c39ddf" }
+    ap-northeast-1               = { linuxamd64 = "ami-098625a3c9363408e", linuxarm64 = "ami-0278f0b57f8e49447", windows = "ami-01f1fc113c3b0b3fa", ubuntu2404amd64 = "ami-0c78b9961a007987e", ubuntu2404arm64 = "ami-066df7bda9ac1f404" }
+    ap-southeast-2               = { linuxamd64 = "ami-0d22d428945a4e018", linuxarm64 = "ami-090329e02370990c3", windows = "ami-0ae504011bb6b31b8", ubuntu2404amd64 = "ami-0cbd7e937968a1da8", ubuntu2404arm64 = "ami-05df281ef92dfe191" }
+    ap-southeast-1               = { linuxamd64 = "ami-0cae6deda19a6658b", linuxarm64 = "ami-059c8baf137353b61", windows = "ami-0b4d62cdfd3d3ed00", ubuntu2404amd64 = "ami-0920e2913f6d0f567", ubuntu2404arm64 = "ami-027f195c106ab6bd2" }
+    ca-central-1                 = { linuxamd64 = "ami-06ac6fd281aae1e31", linuxarm64 = "ami-0ff357e14ad16cfdd", windows = "ami-0ce6e935e39e5e00e", ubuntu2404amd64 = "ami-02103eaca038579b5", ubuntu2404arm64 = "ami-040a87d99fd7d59e9" }
+    eu-central-1                 = { linuxamd64 = "ami-0d33b6fabb226293a", linuxarm64 = "ami-08321b2cc56650806", windows = "ami-0b2ef5595b2de9f50", ubuntu2404amd64 = "ami-00648219d48c076f6", ubuntu2404arm64 = "ami-0fd63dbfb43ae0e01" }
+    eu-west-1                    = { linuxamd64 = "ami-0a3077811c1b4a6b1", linuxarm64 = "ami-01a25e691d79e0124", windows = "ami-0e533f9f2728e1aa4", ubuntu2404amd64 = "ami-02fb2309b9ee5ada8", ubuntu2404arm64 = "ami-07fb33deff5c9fd2e" }
+    eu-west-2                    = { linuxamd64 = "ami-095d23290f492524c", linuxarm64 = "ami-05319fbdca0a69d01", windows = "ami-0adb94ea6dfa5f177", ubuntu2404amd64 = "ami-082b39921ada47323", ubuntu2404arm64 = "ami-001b08e1e40ebb3de" }
+    eu-south-1                   = { linuxamd64 = "ami-06b527f17bcc16988", linuxarm64 = "ami-04848aec3ff89c648", windows = "ami-0d082ec33b9f88623", ubuntu2404amd64 = "ami-06e166335169af76d", ubuntu2404arm64 = "ami-0b0ff616ab8ad2adf" }
+    eu-west-3                    = { linuxamd64 = "ami-016ecade7bf852154", linuxarm64 = "ami-07ae195d8f798e142", windows = "ami-052f27bcb7d54b4cf", ubuntu2404amd64 = "ami-019da3aba8be2a9af", ubuntu2404arm64 = "ami-03022e7acec218250" }
+    eu-north-1                   = { linuxamd64 = "ami-07da6b66a5ab5c9ce", linuxarm64 = "ami-03358eb49fc229625", windows = "ami-0b4fc10ac561b58ed", ubuntu2404amd64 = "ami-0b45eb9fea069eaec", ubuntu2404arm64 = "ami-06b2edf02c99c234d" }
+    sa-east-1                    = { linuxamd64 = "ami-0d37f74b294d8044a", linuxarm64 = "ami-0d969c59a8304638c", windows = "ami-0b8028006ed96ce10", ubuntu2404amd64 = "ami-0de8ecf6f64b6d4a4", ubuntu2404arm64 = "ami-0e6c3800237124a1b" }
+    cloudformation_stack_version = "v6.70.0"
   }
 
   # Region-specific Lambda deployment bucket
@@ -91,9 +91,12 @@ locals {
   # https://docs.aws.amazon.com/ec2/latest/instancetypes/instance-type-names.html
   is_burstable_instance = can(regex("^t[0-9]", local.instance_type_family))
 
-  is_windows       = var.instance_operating_system == "windows"
-  ami_architecture = local.is_windows ? "windows" : (local.is_arm_instance ? "linuxarm64" : "linuxamd64")
-  selected_ami_id  = local.buildkite_ami_mapping[data.aws_region.current.region][local.ami_architecture]
+  is_windows = var.instance_operating_system == "windows"
+  is_ubuntu  = !local.is_windows && var.linux_distribution == "ubuntu2404"
+  ami_architecture = local.is_windows ? "windows" : (
+    local.is_ubuntu ? (local.is_arm_instance ? "ubuntu2404arm64" : "ubuntu2404amd64") : (local.is_arm_instance ? "linuxarm64" : "linuxamd64")
+  )
+  selected_ami_id = local.buildkite_ami_mapping[data.aws_region.current.region][local.ami_architecture]
 
   # Instance naming and timeout settings
   use_default_timeout      = var.instance_creation_timeout == ""
@@ -132,8 +135,8 @@ locals {
   # Determine AMI ID from custom, parameter, or Buildkite mapping
   computed_ami_id = local.use_custom_ami ? var.image_id : (local.use_ami_parameter ? data.aws_ssm_parameter.ami[0].value : local.selected_ami_id)
 
-  # Determine root volume device name based on OS
-  root_device_name = local.use_default_volume_name ? (local.is_windows ? "/dev/sda1" : "/dev/xvda") : var.root_volume_name
+  # Windows and Ubuntu AMIs root on /dev/sda1; Amazon Linux roots on /dev/xvda.
+  root_device_name = local.use_default_volume_name ? (local.is_windows || local.is_ubuntu ? "/dev/sda1" : "/dev/xvda") : var.root_volume_name
 
   # SSH key and authorized users settings
   use_ssh_key        = var.key_name != ""

--- a/scripts/user-data-linux.sh
+++ b/scripts/user-data-linux.sh
@@ -30,15 +30,6 @@ BUILDKITE_ENABLE_INSTANCE_STORAGE="${enable_instance_storage}" \
 --==BOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash -v
-# Ensure SSM Agent is installed and running
-yum update -y
-yum install -y amazon-ssm-agent
-systemctl enable amazon-ssm-agent
-systemctl start amazon-ssm-agent
-systemctl status amazon-ssm-agent
---==BOUNDARY==
-Content-Type: text/x-shellscript; charset="us-ascii"
-#!/bin/bash -v
 BUILDKITE_STACK_NAME="${stack_name}" \
 BUILDKITE_STACK_VERSION="${stack_version}" \
 BUILDKITE_STACK_DEPLOYED_BY="${stack_deployed_by}" \

--- a/tests/linux_distribution.tftest.hcl
+++ b/tests/linux_distribution.tftest.hcl
@@ -1,0 +1,133 @@
+mock_provider "aws" {
+  mock_data "aws_region" {
+    override_during = plan
+    defaults = {
+      id     = "us-east-1"
+      region = "us-east-1"
+    }
+  }
+
+  mock_data "aws_caller_identity" {
+    override_during = plan
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:user/test"
+      user_id    = "test"
+    }
+  }
+
+  mock_data "aws_partition" {
+    override_during = plan
+    defaults = {
+      partition  = "aws"
+      dns_suffix = "amazonaws.com"
+    }
+  }
+
+  mock_data "aws_availability_zones" {
+    override_during = plan
+    defaults = {
+      names = ["us-east-1a", "us-east-1b"]
+    }
+  }
+}
+
+mock_provider "archive" {}
+
+mock_provider "random" {
+  mock_resource "random_id" {
+    override_during = plan
+    defaults = {
+      hex = "01234567"
+    }
+  }
+}
+
+run "defaults_to_amazon_linux_2023" {
+  command = plan
+
+  variables {
+    buildkite_agent_token = "test-token"
+  }
+
+  assert {
+    condition     = aws_launch_template.agent_launch_template.image_id == local.buildkite_ami_mapping["us-east-1"].linuxamd64
+    error_message = "The default Linux distribution should use the Amazon Linux 2023 amd64 AMI."
+  }
+
+  assert {
+    condition     = aws_launch_template.agent_launch_template.block_device_mappings[0].device_name == "/dev/xvda"
+    error_message = "Amazon Linux should use /dev/xvda as its default root device."
+  }
+}
+
+run "selects_ubuntu_2404_amd64" {
+  command = plan
+
+  variables {
+    buildkite_agent_token_parameter_store_path = "/buildkite/test-token"
+    linux_distribution                         = "ubuntu2404"
+    secrets_bucket                             = "test-secrets-bucket"
+  }
+
+  assert {
+    condition     = aws_launch_template.agent_launch_template.image_id == local.buildkite_ami_mapping["us-east-1"].ubuntu2404amd64
+    error_message = "Ubuntu 24.04 on amd64 should use the matching AMI."
+  }
+
+  assert {
+    condition     = aws_launch_template.agent_launch_template.block_device_mappings[0].device_name == "/dev/sda1"
+    error_message = "Ubuntu should use /dev/sda1 as its default root device."
+  }
+
+  assert {
+    condition     = !strcontains(base64decode(aws_launch_template.agent_launch_template.user_data), "yum install")
+    error_message = "Linux user data should not run Amazon Linux-specific package installation on Ubuntu."
+  }
+}
+
+run "selects_ubuntu_2404_arm64" {
+  command = plan
+
+  variables {
+    buildkite_agent_token = "test-token"
+    instance_types        = "t4g.large"
+    linux_distribution    = "ubuntu2404"
+  }
+
+  assert {
+    condition     = aws_launch_template.agent_launch_template.image_id == local.buildkite_ami_mapping["us-east-1"].ubuntu2404arm64
+    error_message = "Ubuntu 24.04 on arm64 should use the matching AMI."
+  }
+}
+
+run "linux_distribution_does_not_affect_windows" {
+  command = plan
+
+  variables {
+    buildkite_agent_token     = "test-token"
+    instance_operating_system = "windows"
+    linux_distribution        = "ubuntu2404"
+  }
+
+  assert {
+    condition     = aws_launch_template.agent_launch_template.image_id == local.buildkite_ami_mapping["us-east-1"].windows
+    error_message = "The Linux distribution setting should not affect Windows AMI selection."
+  }
+
+  assert {
+    condition     = aws_launch_template.agent_launch_template.block_device_mappings[0].device_name == "/dev/sda1"
+    error_message = "Windows should continue to use /dev/sda1 as its default root device."
+  }
+}
+
+run "rejects_unknown_linux_distribution" {
+  command = plan
+
+  variables {
+    buildkite_agent_token = "test-token"
+    linux_distribution    = "debian"
+  }
+
+  expect_failures = [var.linux_distribution]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -360,6 +360,17 @@ variable "instance_operating_system" {
   }
 }
 
+variable "linux_distribution" {
+  description = "The Linux distribution to run on the instances. Only applies when instance_operating_system is 'linux'."
+  type        = string
+  default     = "amazonlinux2023"
+
+  validation {
+    condition     = contains(["amazonlinux2023", "ubuntu2404"], var.linux_distribution)
+    error_message = "linux_distribution must be 'amazonlinux2023' or 'ubuntu2404'."
+  }
+}
+
 variable "instance_name" {
   description = "Optional - Customize the EC2 instance Name tag."
   type        = string
@@ -604,13 +615,13 @@ variable "associate_public_ip_address" {
 # =============================================================================
 
 variable "key_name" {
-  description = "Optional - SSH keypair used to access the Buildkite instances via ec2-user, setting this will enable SSH ingress."
+  description = "Optional - SSH keypair used to access the Buildkite instances via the default login user (ec2-user on Amazon Linux, ubuntu on Ubuntu), setting this will enable SSH ingress."
   type        = string
   default     = ""
 }
 
 variable "authorized_users_url" {
-  description = "Optional - HTTPS or S3 URL to periodically download SSH authorized_keys from, setting this will enable SSH ingress. authorized_keys are applied to ec2-user."
+  description = "Optional - HTTPS or S3 URL to periodically download SSH authorized_keys from, setting this will enable SSH ingress. authorized_keys are applied to the default login user (ec2-user on Amazon Linux, ubuntu on Ubuntu)."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Add a linux_distribution attribute and select the maching AMI and root device.
Remove redundant SSM Agent setup since it's now included in the AMIs. Also, update AMI mappings, tests, and documentation.