### PR TITLE
feat: add option for updating default launch template version

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -7,6 +7,8 @@ data "aws_ssm_parameter" "ami" {
 resource "aws_launch_template" "agent_launch_template" {
   name = "${local.stack_name_full}-launch-template"
 
+  update_default_version = var.update_default_launch_template_version
+
   tags = local.common_tags
 
   network_interfaces {

--- a/variables.tf
+++ b/variables.tf
@@ -1169,9 +1169,9 @@ variable "tags" {
 }
 
 variable "update_default_launch_template_version" {
-  description = "Whether to update the default launch template version."
+  description = "When true, Terraform sets the launch template default version to the latest version it creates. This stack's ASG already uses $Latest, so agent launches are unaffected; enable this for other consumers that launch the template with $Default."
   type        = bool
-  default     = null
+  default     = false
 }
 
 # =============================================================================

--- a/variables.tf
+++ b/variables.tf
@@ -1168,6 +1168,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "update_default_launch_template_version" {
+  description = "Whether to update the default launch template version."
+  type        = bool
+  default     = null
+}
+
 # =============================================================================
 # CROSS-VARIABLE VALIDATIONS
 # =============================================================================


### PR DESCRIPTION
It would just be nice to give people the option to let terraform set the new launch template version that it creates (when it makes changes after you, say, edit the user data on the launch template version) as the default version. 